### PR TITLE
Add typing_extensions for Python 3.7

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9" ]
+        python-version: [ "3.7", "3.8", "3.9" ]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/cpas_toolbox/datasets/nocs_dataset.py
+++ b/cpas_toolbox/datasets/nocs_dataset.py
@@ -2,25 +2,31 @@
 import datetime
 import imghdr
 import json
-from glob import glob
 import os
 import pickle
-from shutil import copyfile
+import sys
 import time
-from typing import TypedDict, Optional, List
 import zipfile
+from glob import glob
+from shutil import copyfile
+from typing import List, Optional
 
-from joblib import Parallel, delayed
-from scipy.spatial.transform import Rotation
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 8:
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
 import numpy as np
 import open3d as o3d
 import pandas as pd
 import torch
-from PIL import Image
 import yoco
+from joblib import Parallel, delayed
+from PIL import Image
+from scipy.spatial.transform import Rotation
 from tqdm import tqdm
 
-from cpas_toolbox import pointset_utils, quaternion_utils, camera_utils, utils
+from cpas_toolbox import camera_utils, pointset_utils, quaternion_utils, utils
 from cpas_toolbox.datasets import nocs_utils
 
 
@@ -646,7 +652,7 @@ class NOCSDataset(torch.utils.data.Dataset):
             nocs_transform = gts_data["gt_RTs"][gt_id]
             position = nocs_transform[0:3, 3]
             rot_scale = nocs_transform[0:3, 0:3]
-            nocs_scales = np.sqrt(np.sum(rot_scale ** 2, axis=0))
+            nocs_scales = np.sqrt(np.sum(rot_scale**2, axis=0))
             rotation_matrix = rot_scale / nocs_scales[:, None]
             nocs_scale = nocs_scales[0]
         else:  # camera_train, camera_val, real_train

--- a/cpas_toolbox/datasets/redwood_dataset.py
+++ b/cpas_toolbox/datasets/redwood_dataset.py
@@ -1,15 +1,21 @@
 """Module providing dataset class for annotated Redwood dataset."""
 import json
 import os
-from typing import TypedDict, Optional
+import sys
 import zipfile
+from typing import Optional
 
-from scipy.spatial.transform import Rotation
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 8:
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
 import numpy as np
 import open3d as o3d
 import torch
-from PIL import Image
 import yoco
+from PIL import Image
+from scipy.spatial.transform import Rotation
 
 from cpas_toolbox import camera_utils, pointset_utils, quaternion_utils, utils
 

--- a/cpas_toolbox/method_wrappers.py
+++ b/cpas_toolbox/method_wrappers.py
@@ -1,21 +1,34 @@
 """Wrapper for pose and shape estimation methods."""
-from abc import ABC
 import copy
 import os
 import shutil
-from typing import List, Optional, TypedDict
+import sys
 import zipfile
+from abc import ABC
+from typing import List, Optional
+
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 8:
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 import cv2
 import numpy as np
 import open3d as o3d
 import torch
 import torchvision.transforms.functional as TF
-from scipy.spatial.transform import Rotation
 import yoco
+from scipy.spatial.transform import Rotation
 
-from cpas_toolbox import pointset_utils, quaternion_utils, camera_utils, utils
-from cpas_toolbox import cass, asmnet, spd
+from cpas_toolbox import (
+    asmnet,
+    camera_utils,
+    cass,
+    pointset_utils,
+    quaternion_utils,
+    spd,
+    utils,
+)
 
 
 class PredictionDict(TypedDict):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,29 @@
+import sys
+
 import setuptools
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+install_requires = [
+    "gdown",
+    "matplotlib",
+    "numpy",
+    "open3d",
+    "opencv-python-headless",
+    "Pillow",
+    "requests",
+    "scipy",
+    "tikzplotlib",
+    "torch",
+    "torchvision",
+    "tqdm",
+    "trimesh",
+    "yoco",
+]
+
+if sys.version_info[0] <= 3 and sys.version_info[1] < 8:
+    install_requires.append("typing_extensions")
 
 setuptools.setup(
     name="cpas_toolbox",
@@ -14,22 +36,7 @@ setuptools.setup(
     url="https://github.com/roym899/pose_and_shape_evaluation",
     packages=setuptools.find_packages(),
     package_data={"": ["config/*"]},
-    install_requires=[
-        "gdown",
-        "matplotlib",
-        "numpy",
-        "open3d",
-        "opencv-python-headless",
-        "Pillow",
-        "requests",
-        "scipy",
-        "tikzplotlib",
-        "torch",
-        "torchvision",
-        "tqdm",
-        "trimesh",
-        "yoco",
-    ],
+    install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
@@ -37,5 +44,5 @@ setuptools.setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
`TypedDict` has been added in Python 3.8. This adds `typing_extensions` module only for Python <3.8.
Also dropping Python 3.6 support since it reached its [end of life](https://endoflife.date/python).